### PR TITLE
BidirectedGraph (HG -> Deletable HG)

### DIFF
--- a/deps/handlegraph/deletable_handle_graph.hpp
+++ b/deps/handlegraph/deletable_handle_graph.hpp
@@ -1,0 +1,47 @@
+#ifndef HANDLEGRAPH_DELETABLE_HANDLE_GRAPH_HPP_INCLUDED
+#define HANDLEGRAPH_DELETABLE_HANDLE_GRAPH_HPP_INCLUDED
+
+/** \file 
+ * Defines the DeletableHandleGraph interface for graphs that can have material removed.
+ */
+
+#include "mutable_handle_graph.hpp"
+
+namespace handlegraph {
+
+/**
+ * This is the interface for a handle graph that supports both addition of new nodes and edges
+ * as well as deletion of nodes and edges.
+ */
+class DeletableHandleGraph : virtual public MutableHandleGraph {
+public:
+    
+    virtual ~DeletableHandleGraph() = default;
+    
+    /// Remove the node belonging to the given handle and all of its edges.
+    /// Does not update any stored paths.
+    /// Invalidates the destroyed handle.
+    /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
+    /// May **NOT** be called during parallel for_each_handle iteration.
+    /// May **NOT** be called on the node from which edges are being followed during follow_edges.
+    virtual void destroy_handle(const handle_t& handle) = 0;
+    
+    /// Remove the edge connecting the given handles in the given order and orientations.
+    /// Ignores nonexistent edges.
+    /// Does not update any stored paths.
+    virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
+    
+    /// Convenient wrapper for destroy_edge.
+    inline void destroy_edge(const edge_t& edge) {
+        destroy_edge(edge.first, edge.second);
+    }
+    
+    /// Remove all nodes and edges.
+    virtual void clear() = 0;
+};
+
+}
+
+#endif
+
+

--- a/src/BidirectedGraph.cpp
+++ b/src/BidirectedGraph.cpp
@@ -10,6 +10,11 @@
 using namespace std;
 #endif /* DEBUG_BIDIRECTED_GRAPH */
 
+
+//******************************************************************************
+// Non handle graph functions 
+//******************************************************************************
+
 /// Deserializes vg JSON fromat
 /// Returns true if deserialize successfully or false if otherwise
 bool BidirectedGraph::deserialize(ifstream& infile) {
@@ -36,10 +41,6 @@ bool BidirectedGraph::deserialize(ifstream& infile) {
     return true;
 }
 
-// vector<const handle_t> BidirectedGraph::get_reachable_nodes(handle_t id){
-//     return reachable_nodes[get_id(id)];
-// }
-
 void BidirectedGraph::add_edge(nid_t id1, nid_t id2, bool from_left, bool to_right){
     BidirectedEdge from_id1(id1, id2, from_left, to_right);
     edges.emplace(make_pair(id1, vector<BidirectedEdge>()));
@@ -53,138 +54,9 @@ void BidirectedGraph::add_edge(nid_t id1, nid_t id2, bool from_left, bool to_rig
     edges[id2].push_back(from_id2);
 }
 
-// bool BidirectedGraph::is_acyclic(){
-//     return true;
-// }
-// //idk if this works
-// void BidirectedGraph::populate_reachable_nodes(){
-    
-//     unordered_map<const nid_t, char > colormap;
-//     for_each_handle_impl([&] (const handle_t& handle) {
-//         vector<const handle_t> component;
-//         queue<handle_t> queue;
-//         queue.push(handle);
-//         colormap[get_id(handle)] = 'g';
-//         while(queue.size()!=0){
-//             handle_t currnode = queue.front();
-//             queue.pop();
-//             follow_edges_impl(currnode, true, [&](const handle_t& handle){
-//                 if(colormap.find(get_id(handle))!=colormap.end()){
-//                     return true;
-//                 }
-//                 ((vector<const handle_t>) component).push_back(handle);
-//                 colormap[get_id(handle)] = 'g';
-//                 return true;
-//             });
-//         }
-//         colormap[get_id(handle)] = 'b';
-//         vector<const handle_t>::iterator iter= component.begin();
-//         while(iter!=component.end()){
-//             reachable_nodes.emplace(make_pair(get_id(*iter), component));
-//         }
-//         return true;
-//     }, false);
-// }
-
-
-// lowercase g means entering from left
-// uppercase G means entering from right
-//void BidirectedGraph::mod_BFS(nid_t id){
-    /*
-    if(reachable_nodes.find(id)==reachable_nodes.end()){
-        reachable_nodes.emplace(id, vector<handle_t>());
-    }
-    
-    queue<nid_t> queue = ::queue<nid_t>();
-    queue.push(id);
-    colormap.emplace(make_pair(id, 'g'));
-    while(queue.size()!=0){
-        nid_t currnode = queue.front();
-        queue.pop();
-        char color = colormap.at(currnode);
-        vector<BidirectedEdge>::iterator veciter = edges.at(id).begin();
-        while(veciter!=edges.at(id).end()){
-            if(color=='g'){
-                if(veciter->id1==currnode && !veciter->from_left && colormap.find(veciter->id2)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id2, false));
-                    queue.push(veciter->id2);
-                    colormap.emplace(veciter->id2, veciter->to_right ? 'G' : 'g');
-                }
-                else if(veciter->id2==currnode && veciter->to_right && colormap.find(veciter->id1)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id1, false));
-                    queue.push(veciter->id1);
-                    colormap.emplace(veciter->id1, veciter->from_left ? 'g' : 'G');
-                }
-            }
-            else if(color=='G'){
-                if(veciter->id1==currnode && veciter->from_left && colormap.find(veciter->id2)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id2, false));
-                    queue.push(veciter->id2);
-                    colormap.emplace(veciter->id2, veciter->to_right ? 'G' : 'g');
-                }
-                else if(veciter->id2==currnode && !veciter->to_right && colormap.find(veciter->id1)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id1, false));
-                    queue.push(veciter->id1);
-                    colormap.emplace(veciter->id1, veciter->from_left ? 'g' : 'G');
-                }
-            }
-            ++veciter;
-        }
-        colormap.at(currnode) = 'b';
-    }
-    queue = ::queue<nid_t>();
-    colormap = unordered_map<nid_t, char>();
-    queue.push(id);
-    colormap.emplace(make_pair(id, 'G'));
-    while(queue.size()!=0){
-        nid_t currnode = queue.front();
-        queue.pop();
-        char color = colormap.at(currnode);
-        vector<BidirectedEdge>::iterator veciter = edges.at(id).begin();
-        while(veciter!=edges.at(id).end()){
-            if(color=='g'){
-                if(veciter->id1==currnode && !veciter->from_left && colormap.find(veciter->id2)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id2, false));
-                    queue.push(veciter->id2);
-                    colormap.emplace(veciter->id2, veciter->to_right ? 'G' : 'g');
-                }
-                else if(veciter->id2==currnode && veciter->to_right && colormap.find(veciter->id1)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id1, false));
-                    queue.push(veciter->id1);
-                    colormap.emplace(veciter->id1, veciter->from_left ? 'g' : 'G');
-                }
-            }
-            else if(color=='G'){
-                if(veciter->id1==currnode && veciter->from_left && colormap.find(veciter->id2)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id2, false));
-                    queue.push(veciter->id2);
-                    colormap.emplace(veciter->id2, veciter->to_right ? 'G' : 'g');
-                }
-                else if(veciter->id2==currnode && !veciter->to_right && colormap.find(veciter->id1)==colormap.end()){
-                    reachable_nodes.at(id).push_back(get_handle(veciter->id1, false));
-                    queue.push(veciter->id1);
-                    colormap.emplace(veciter->id1, veciter->from_left ? 'g' : 'G');
-                }
-            }
-            ++veciter;
-        }
-        colormap.at(currnode) = 'b';
-    }
-    */
-//}
-
-// void BidirectedGraph::print_reachable_nodes(){
-//     unordered_map<nid_t, vector<const handle_t> >::iterator reachable = reachable_nodes.begin();
-//     while(reachable!=reachable_nodes.end()){
-//         vector<const handle_t>::iterator nodeiter = reachable->second.begin();
-//         printf("Printing path connected nodes from %llu:\n", reachable->first);
-//         while(nodeiter!=reachable->second.end()){
-//             printf("%llu\n", get_id(*nodeiter));
-//             nodeiter++;
-//         }
-//         reachable++;
-//     }
-// }
+//******************************************************************************
+// Handle graph public functions 
+//******************************************************************************
 
 /// Method to check if a node exists by ID
 bool BidirectedGraph::has_node(nid_t nodeid) const {
@@ -218,7 +90,7 @@ size_t BidirectedGraph::get_length(const handle_t& handle) const {
 
 /// Get the sequence of a node, presented in the handle's local forward
 /// orientation.
-std::string BidirectedGraph::get_sequence(const handle_t& handle) const {
+string BidirectedGraph::get_sequence(const handle_t& handle) const {
     return "";
 }
 
@@ -254,7 +126,67 @@ nid_t BidirectedGraph::max_node_id() const {
     return 0;
 }
 
-bool BidirectedGraph::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+//******************************************************************************
+// Mutable handle graph public functions 
+//******************************************************************************
+
+handle_t BidirectedGraph::create_handle(const string& sequence) {
+
+}
+
+handle_t BidirectedGraph::create_handle(const string& sequence, const nid_t& id) {
+
+}
+
+void BidirectedGraph::create_edge(const handle_t& left, const handle_t& right) {
+
+}
+
+handle_t BidirectedGraph::apply_orientation(const handle_t& handle) {
+
+}
+
+vector<handle_t> BidirectedGraph::divide_handle(const handle_t& handle, const vector<size_t>& offsets) {
+
+}
+
+void BidirectedGraph::optimize(bool allow_id_reassignment) {
+
+}
+
+void BidirectedGraph::apply_ordering(const vector<handle_t>& order, bool compact_ids) {
+
+}
+
+void BidirectedGraph::set_id_increment(const nid_t& min_id) {
+
+}
+
+void BidirectedGraph::reassign_node_ids(const function<nid_t(const nid_t&)>& get_new_id) {
+
+}
+
+//******************************************************************************
+// Deletable handle graph public functions
+//******************************************************************************
+
+void BidirectedGraph::destroy_handle(const handle_t& handle) {
+
+}
+
+void BidirectedGraph::destroy_edge(const handle_t& left, const handle_t& right) {
+
+}
+
+void BidirectedGraph::clear() {
+
+}
+
+//******************************************************************************
+// Handle graph protected functions
+//******************************************************************************
+
+bool BidirectedGraph::follow_edges_impl(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const {
     nid_t node_id    = get_id(handle);
     bool  is_reverse = get_is_reverse(handle);
     bool  on_left    = (go_left && !is_reverse) || (!go_left && is_reverse);
@@ -268,7 +200,7 @@ bool BidirectedGraph::follow_edges_impl(const handle_t& handle, bool go_left, co
 }
         
 
-bool BidirectedGraph::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+bool BidirectedGraph::for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
     for (const auto& node_edges : edges) {
         if (!iteratee(get_handle(node_edges.first, false))) {
             return false;
@@ -276,18 +208,3 @@ bool BidirectedGraph::for_each_handle_impl(const std::function<bool(const handle
     }
     return true;
 }
-
-#ifdef DEBUG_BIDIRECTED_GRAPH
-inline void pprint_edge(const BidirectedEdge& edge) {
-    cout << " - " << "Node " << edge.id1 << ((edge.from_left) ? '-' : '+') << " <-> " << "Node " << edge.id2 << ((edge.to_right) ? '+' : '-') << endl;
-}
-
-void BidirectedGraph::print_edges() const {
-    for (const auto& node_edges : edges) {
-        cout << "Node " << node_edges.first << endl;
-        for (const BidirectedEdge& edge : node_edges.second) {
-            pprint_edge(edge);
-        }
-    }
-}
-#endif /* DEBUG_BIDIRECTED_GRAPH */

--- a/src/BidirectedGraph.cpp
+++ b/src/BidirectedGraph.cpp
@@ -1,6 +1,4 @@
 #include "BidirectedGraph.hpp"
-#include <string>
-#include <queue>
 #include "../deps/json/json/json.h"
 
 #include "../deps/handlegraph/util.hpp"
@@ -30,28 +28,25 @@ bool BidirectedGraph::deserialize(ifstream& infile) {
     }
 
     /// TODO: check if it's proper vg JSON format
+
+    /// Construct nodes
+    Json::Value nodes = graph_json["node"];
+    for (auto& node : nodes) {
+        nid_t id1 = node["id"].asInt64();
+        string sequence = node["sequence"].asString();
+        create_handle(sequence, id1);
+    }
+
+    /// Construct edges
     Json::Value edges = graph_json["edge"];
     for (auto& edge : edges) {
         nid_t id1 = edge["from"].asInt64();
         nid_t id2 = edge["to"].asInt64();
         bool from_left = edge.get("from_start", false).asBool();
         bool to_right = edge.get("to_end", false).asBool();
-        add_edge(id1, id2, from_left, to_right);
+        create_edge(get_handle(id1, from_left), get_handle(id2, to_right));
     }
     return true;
-}
-
-void BidirectedGraph::add_edge(nid_t id1, nid_t id2, bool from_left, bool to_right){
-    BidirectedEdge from_id1(id1, id2, from_left, to_right);
-    edges.emplace(make_pair(id1, vector<BidirectedEdge>()));
-    edges[id1].push_back(from_id1);
-
-    /// Make a complement edge for id2 if the edge doesn't leave and enter the same node side
-    if (id1 == id2 && from_left != to_right) return;
-
-    BidirectedEdge from_id2(id2, id1, !to_right, !from_left);
-    edges.emplace(make_pair(id2, vector<BidirectedEdge>()));
-    edges[id2].push_back(from_id2);
 }
 
 //******************************************************************************
@@ -60,7 +55,7 @@ void BidirectedGraph::add_edge(nid_t id1, nid_t id2, bool from_left, bool to_rig
 
 /// Method to check if a node exists by ID
 bool BidirectedGraph::has_node(nid_t nodeid) const {
-    return edges.find(nodeid) != edges.end();
+    return nodes.count(nodeid);
 }
 
 /// Look up the handle for the node with the given ID in the given orientation
@@ -85,30 +80,30 @@ handle_t BidirectedGraph::flip(const handle_t& handle) const {
 
 /// Get the length of a node
 size_t BidirectedGraph::get_length(const handle_t& handle) const {
-    return 0;
+    return get_sequence(handle).size();
 }
 
 /// Get the sequence of a node, presented in the handle's local forward
 /// orientation.
 string BidirectedGraph::get_sequence(const handle_t& handle) const {
-    return "";
+    return nodes.at(get_id(handle));
 }
 
 /// Return the number of nodes in the graph
 size_t BidirectedGraph::get_node_count() const {
-    return edges.size();
+    return nodes.size();
 }
 
 /// Return the smallest ID in the graph, or some smaller number if the
 /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t BidirectedGraph::min_node_id() const {
-    // Should work with default comparator, otherwise use
-    edge_map::const_iterator res = min_element(edges.begin(), edges.end(),
-                                        [](const edge_map_pair& node1, const edge_map_pair& node2) {
-                                            return node1.first < node2.first;
-                                        });
-    if (res != edges.end()) {
-        return res->first;
+    auto res = min_element(nodes.begin(), nodes.end(),
+        [] (const auto& n1, const auto& n2) {
+            return n1.first < n2.first;
+        }
+    );
+    if (res != nodes.end()) {
+        return res->first;   
     }
     return 0;
 }
@@ -116,11 +111,12 @@ nid_t BidirectedGraph::min_node_id() const {
 /// Return the largest ID in the graph, or some larger number if the
 /// largest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t BidirectedGraph::max_node_id() const {
-    edge_map::const_iterator res = max_element(edges.begin(), edges.end(),
-                                        [](const edge_map_pair& node1, const edge_map_pair& node2) {
-                                            return node1.first < node2.first;
-                                        });
-    if (res != edges.end()) {
+    auto res = max_element(nodes.begin(), nodes.end(),
+        [](const auto& n1, const auto& n2) {
+            return n1.first < n2.first;
+        }
+    );
+    if (res != nodes.end()) {
         return res->first;
     }
     return 0;
@@ -131,39 +127,51 @@ nid_t BidirectedGraph::max_node_id() const {
 //******************************************************************************
 
 handle_t BidirectedGraph::create_handle(const string& sequence) {
-
+    nodes[cur_id] = sequence;
+    cur_id++; /// Increment node id
+    return get_handle(cur_id - 1);
 }
 
 handle_t BidirectedGraph::create_handle(const string& sequence, const nid_t& id) {
-
+    nodes[id] = sequence;
+    cur_id = (id > cur_id) ? id + 1 : cur_id; // Simple cur_id update function
+    return get_handle(id);
 }
 
 void BidirectedGraph::create_edge(const handle_t& left, const handle_t& right) {
+    /// From left to right
+    edges.emplace(left, unordered_set<handle_t>());
+    edges[left].insert(right);
 
+    /// Create complement from right to left
+    edges.emplace(flip(right), unordered_set<handle_t>());
+    edges[flip(right)].insert(flip(left));
 }
 
 handle_t BidirectedGraph::apply_orientation(const handle_t& handle) {
-
+    /// TODO: Incorrect implementation
+    return handle;
 }
 
 vector<handle_t> BidirectedGraph::divide_handle(const handle_t& handle, const vector<size_t>& offsets) {
-
+    /// TODO: Incorrect implementation
+    return vector<handle_t>();
 }
 
 void BidirectedGraph::optimize(bool allow_id_reassignment) {
-
+    /// TODO: Incorrect implementation
 }
 
 void BidirectedGraph::apply_ordering(const vector<handle_t>& order, bool compact_ids) {
-
+    /// TODO: Incorrect implementation
 }
 
 void BidirectedGraph::set_id_increment(const nid_t& min_id) {
-
+    /// TODO: Incorrect implementation
 }
 
 void BidirectedGraph::reassign_node_ids(const function<nid_t(const nid_t&)>& get_new_id) {
-
+    /// TODO: Incorrect implementation
 }
 
 //******************************************************************************
@@ -171,15 +179,29 @@ void BidirectedGraph::reassign_node_ids(const function<nid_t(const nid_t&)>& get
 //******************************************************************************
 
 void BidirectedGraph::destroy_handle(const handle_t& handle) {
+    /// Erase from nodes
+    nodes.erase(get_id(handle));
 
+    /// Remove edges
+    handle_t flipped = flip(handle);
+    /// Remove complement edges
+    for (auto& rhandle : edges[handle]) {
+        edges[flip(rhandle)].erase(flipped);
+    }
+    /// Delete "forward edges" from handle
+    edges.erase(handle);
 }
 
 void BidirectedGraph::destroy_edge(const handle_t& left, const handle_t& right) {
-
+    /// Erase forward edge
+    edges[left].erase(right);
+    /// Erase complement edge
+    edges[flip(right)].erase(flip(left));
 }
 
 void BidirectedGraph::clear() {
-
+    nodes.clear();
+    edges.clear();
 }
 
 //******************************************************************************
@@ -187,24 +209,25 @@ void BidirectedGraph::clear() {
 //******************************************************************************
 
 bool BidirectedGraph::follow_edges_impl(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const {
-    nid_t node_id    = get_id(handle);
-    bool  is_reverse = get_is_reverse(handle);
-    bool  on_left    = (go_left && !is_reverse) || (!go_left && is_reverse);
-    for (const BidirectedEdge& node_edge : edges.at(node_id)) {
-        bool flow = (node_edge.from_left ^ node_edge.to_right) ^ is_reverse; // The node return should follow the "flow" of the walk
-        if (node_edge.from_left == on_left && !iteratee(get_handle(node_edge.id2, flow))) {
-            return false;
-        }
+    /// Get handle of proper direction
+    handle_t lhandle;
+    if (go_left) lhandle = flip(handle);
+    else lhandle = *const_cast<handle_t*>(&handle);
+
+    /// Early exit if there aren't any edges for that handle
+    if (!edges.count(lhandle)) return true;
+
+    /// Otherwise iterate through every edge
+    for (auto& rhandle : edges.at(lhandle)) {
+        if (!iteratee(rhandle)) return false;
     }
     return true;
 }
         
 
 bool BidirectedGraph::for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel) const {
-    for (const auto& node_edges : edges) {
-        if (!iteratee(get_handle(node_edges.first, false))) {
-            return false;
-        }
+    for (auto& [nid, _] : nodes) {
+        if (!iteratee(get_handle(nid))) return false;
     }
     return true;
 }

--- a/src/BidirectedGraph.cpp
+++ b/src/BidirectedGraph.cpp
@@ -12,11 +12,7 @@ using namespace std;
 
 
 //******************************************************************************
-<<<<<<< HEAD
 // Non handle graph functions 
-=======
-// Non handlegraph/mutable handlegraph functions 
->>>>>>> 5856e31c2da303ca917b814110950b88c63dda7d
 //******************************************************************************
 
 /// Deserializes vg JSON fromat
@@ -59,11 +55,7 @@ void BidirectedGraph::add_edge(nid_t id1, nid_t id2, bool from_left, bool to_rig
 }
 
 //******************************************************************************
-<<<<<<< HEAD
 // Handle graph public functions 
-=======
-// Handlegraph public functions 
->>>>>>> 5856e31c2da303ca917b814110950b88c63dda7d
 //******************************************************************************
 
 /// Method to check if a node exists by ID
@@ -135,11 +127,7 @@ nid_t BidirectedGraph::max_node_id() const {
 }
 
 //******************************************************************************
-<<<<<<< HEAD
 // Mutable handle graph public functions 
-=======
-// Mutable handlegraph public functions 
->>>>>>> 5856e31c2da303ca917b814110950b88c63dda7d
 //******************************************************************************
 
 handle_t BidirectedGraph::create_handle(const string& sequence) {
@@ -179,7 +167,6 @@ void BidirectedGraph::reassign_node_ids(const function<nid_t(const nid_t&)>& get
 }
 
 //******************************************************************************
-<<<<<<< HEAD
 // Deletable handle graph public functions
 //******************************************************************************
 
@@ -197,9 +184,6 @@ void BidirectedGraph::clear() {
 
 //******************************************************************************
 // Handle graph protected functions
-=======
-// Handlegraph protected functions
->>>>>>> 5856e31c2da303ca917b814110950b88c63dda7d
 //******************************************************************************
 
 bool BidirectedGraph::follow_edges_impl(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const {

--- a/src/BidirectedGraph.hpp
+++ b/src/BidirectedGraph.hpp
@@ -8,9 +8,10 @@
 #include <vector>
 #include <unordered_map>
 #include <fstream>
+#include <string>
 
 /* Handlegraph includes */
-#include "../deps/handlegraph/handle_graph.hpp"
+#include "../deps/handlegraph/deletable_handle_graph.hpp"
 #include "../deps/handlegraph/types.hpp"
 
 using namespace std;
@@ -20,7 +21,7 @@ typedef unordered_map<nid_t, vector<const handle_t>> node_map;
 typedef unordered_map<nid_t, vector<BidirectedEdge>> edge_map;
 typedef pair<nid_t, vector<BidirectedEdge>>          edge_map_pair;
 
-class BidirectedGraph : public HandleGraph {
+class BidirectedGraph : public DeletableHandleGraph {
     private:
         node_map reachable_nodes;
         edge_map edges;
@@ -53,7 +54,7 @@ class BidirectedGraph : public HandleGraph {
         
         /// Get the sequence of a node, presented in the handle's local forward
         /// orientation.
-        std::string get_sequence(const handle_t& handle) const;
+        string get_sequence(const handle_t& handle) const;
         
         /// Return the number of nodes in the graph
         size_t get_node_count() const;
@@ -66,15 +67,82 @@ class BidirectedGraph : public HandleGraph {
         /// largest ID is unavailable. Return value is unspecified if the graph is empty.
         nid_t max_node_id() const;
 
-#ifdef DEBUG_BIDIRECTED_GRAPH
-        void print_edges() const;
-#endif /* DEBUG_BIDIRECTED_GRAPH */
+        /// Create a new node with the given sequence and return the handle.
+        handle_t create_handle(const string& sequence);
+
+        /// Create a new node with the given id and sequence, then return the handle.
+        handle_t create_handle(const string& sequence, const nid_t& id);
+        
+        /// Create an edge connecting the given handles in the given order and orientations.
+        /// Ignores existing edges.
+        void create_edge(const handle_t& left, const handle_t& right);
+        
+        /// Alter the node that the given handle corresponds to so the orientation
+        /// indicated by the handle becomes the node's local forward orientation.
+        /// Rewrites all edges pointing to the node and the node's sequence to
+        /// reflect this. Invalidates all handles to the node (including the one
+        /// passed). Returns a new, valid handle to the node in its new forward
+        /// orientation. Note that it is possible for the node's ID to change.
+        /// Does not update any stored paths. May change the ordering of the underlying
+        /// graph.
+        handle_t apply_orientation(const handle_t& handle);
+        
+        /// Split a handle's underlying node at the given offsets in the handle's
+        /// orientation. Returns all of the handles to the parts. Other handles to
+        /// the node being split may be invalidated. The split pieces stay in the
+        /// same local forward orientation as the original node, but the returned
+        /// handles come in the order and orientation appropriate for the handle
+        /// passed in.
+        /// Updates stored paths.
+        vector<handle_t> divide_handle(const handle_t& handle, const vector<size_t>& offsets);
+        
+        /// Adjust the representation of the graph in memory to improve performance.
+        /// Optionally, allow the node IDs to be reassigned to further improve
+        /// performance.
+        /// Note: Ideally, this method is called one time once there is expected to be
+        /// few graph modifications in the future.
+        void optimize(bool allow_id_reassignment = true);
+
+        /// Reorder the graph's internal structure to match that given.
+        /// This sets the order that is used for iteration in functions like for_each_handle.
+        /// Optionally may compact the id space of the graph to match the ordering, from 1->|ordering|.
+        /// This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.
+        void apply_ordering(const vector<handle_t>& order, bool compact_ids = false);
+
+        /// Set a minimum id to increment the id space by, used as a hint during construction.
+        /// May have no effect on a backing implementation.
+        void set_id_increment(const nid_t& min_id);
+
+        /// Renumber all node IDs using the given function, which, given an old ID, returns the new ID.
+        /// Modifies the graph in place. Invalidates all outstanding handles.
+        /// If the graph supports paths, they also must be updated.
+        /// The mapping function may return 0. In this case, the input ID will
+        /// remain unchanged. The mapping function should not return any ID for
+        /// which it would return 0.
+        void reassign_node_ids(const function<nid_t(const nid_t&)>& get_new_id);
+
+        /// Remove the node belonging to the given handle and all of its edges.
+        /// Does not update any stored paths.
+        /// Invalidates the destroyed handle.
+        /// May be called during serial for_each_handle iteration **ONLY** on the node being iterated.
+        /// May **NOT** be called during parallel for_each_handle iteration.
+        /// May **NOT** be called on the node from which edges are being followed during follow_edges.
+        void destroy_handle(const handle_t& handle);
+        
+        /// Remove the edge connecting the given handles in the given order and orientations.
+        /// Ignores nonexistent edges.
+        /// Does not update any stored paths.
+        void destroy_edge(const handle_t& left, const handle_t& right);
+        
+        /// Remove all nodes and edges.
+        void clear();
+
     protected:
         
         /// Loop over all the handles to next/previous (right/left) nodes. Passes
         /// them to a callback which returns false to stop iterating and true to
         /// continue. Returns true if we finished and false if we stopped early.
-        bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+        bool follow_edges_impl(const handle_t& handle, bool go_left, const function<bool(const handle_t&)>& iteratee) const;
         
         /// Loop over all the nodes in the graph in their local forward
         /// orientations, in their internal stored order. Stop if the iteratee
@@ -82,6 +150,6 @@ class BidirectedGraph : public HandleGraph {
         /// after a false return value is on a best-effort basis and iteration
         /// order is not defined. Returns true if we finished and false if we 
         /// stopped early.
-        bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+        bool for_each_handle_impl(const function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
 };
 #endif /* BidirectedGraph_hpp */

--- a/src/BidirectedGraph.hpp
+++ b/src/BidirectedGraph.hpp
@@ -121,7 +121,6 @@ class BidirectedGraph : public DeletableHandleGraph {
         /// which it would return 0.
         void reassign_node_ids(const function<nid_t(const nid_t&)>& get_new_id);
 
-<<<<<<< HEAD
         /// Remove the node belonging to the given handle and all of its edges.
         /// Does not update any stored paths.
         /// Invalidates the destroyed handle.
@@ -138,8 +137,6 @@ class BidirectedGraph : public DeletableHandleGraph {
         /// Remove all nodes and edges.
         void clear();
 
-=======
->>>>>>> 5856e31c2da303ca917b814110950b88c63dda7d
     protected:
         
         /// Loop over all the handles to next/previous (right/left) nodes. Passes

--- a/src/BidirectedGraph.hpp
+++ b/src/BidirectedGraph.hpp
@@ -7,6 +7,7 @@
 /* Data structures for internal representation */
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <fstream>
 #include <string>
 
@@ -17,22 +18,14 @@
 using namespace std;
 using namespace handlegraph;
 
-typedef unordered_map<nid_t, vector<const handle_t>> node_map; 
-typedef unordered_map<nid_t, vector<BidirectedEdge>> edge_map;
-typedef pair<nid_t, vector<BidirectedEdge>>          edge_map_pair;
-
 class BidirectedGraph : public DeletableHandleGraph {
     private:
-        node_map reachable_nodes;
-        edge_map edges;
+        unordered_map<nid_t, string> nodes;
+        unordered_map<handle_t, unordered_set<handle_t>> edges;
+        nid_t cur_id = 0;
+
     public:
         bool deserialize(ifstream& infile);        
-
-        vector<const handle_t> get_reachable_nodes(handle_t node);
-        void add_edge(nid_t id1, nid_t id2, bool from_left, bool to_right);
-        bool is_acyclic();
-        void populate_reachable_nodes();
-        void print_reachable_nodes();
 
         /// Method to check if a node exists by ID
         bool has_node(nid_t node_id) const;

--- a/test/bidirected/Makefile
+++ b/test/bidirected/Makefile
@@ -1,0 +1,38 @@
+# A modified version of Wesley Mackey's Makefile
+
+# Relative path of this directory to the source
+RELPATH    = ../..
+
+WARNING    = -Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast
+COMPILECPP = g++ -std=c++17 -g -O0 ${WARNING}
+
+# Main program
+MAIN_PRG   = bidirected_test.cpp
+# MAIN_PRG   = BundleTest.cpp
+# Bidirected graph sources
+BG_SRCS    = ${RELPATH}/src/BidirectedGraph.cpp 
+# Handlegraph sources
+HG_SRCS    = ${RELPATH}/deps/handlegraph/handle_graph.cpp
+# JSON library sources
+JSON_SRCS  = ${RELPATH}/deps/json/jsoncpp.cpp 
+# Compiled sources and objects
+SOURCES    = ${MAIN_PRG} ${BG_SRCS} ${HG_SRCS} ${JSON_SRCS}
+OBJECTS    = ${SOURCES:.cpp=.o}
+# Executable binary
+EXECBIN    = BidirectedTest 
+
+all : ${EXECBIN}
+
+${EXECBIN} : ${OBJECTS}
+	${COMPILECPP} -o${EXECBIN} ${OBJECTS}
+
+%.o : %.cpp
+	${COMPILECPP} -c $< -o $@
+
+# Removes all intermediate object files but keeps the executable binary
+clean :
+	- rm ${OBJECTS}
+
+# Removes all generated files including the executable binary
+spotless : clean
+	- rm ${EXECBIN}

--- a/test/bidirected/bidirected_test.cpp
+++ b/test/bidirected/bidirected_test.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <string>
+#include <fstream>
+
+#include "../../src/BidirectedGraph.hpp"
+
+using namespace std;
+
+bool remove_node = false;
+
+void print_edges(BidirectedGraph& g) {
+    g.for_each_handle([&](const handle_t& handle) {
+        cout << "Node " << g.get_id(handle) << endl;
+        bool printed = false;
+        cout << "  > Left nodes: ";
+        g.follow_edges(handle, true, [&](const handle_t& child_handle) {
+            cout << g.get_id(child_handle) << (g.get_is_reverse(child_handle) ? "" : "r") << ", ";
+            printed = true;
+        });
+        if (printed) cout << "\b\b  ";
+        cout << endl;
+        printed = false;
+        cout << "  > Right nodes: ";
+        g.follow_edges(handle, false, [&](const handle_t& child_handle) {
+            cout << g.get_id(child_handle) << (g.get_is_reverse(child_handle) ? "r" : "") << ", ";
+            printed = true;
+        });
+        if (printed) cout << "\b\b  ";
+        cout << endl;
+    });
+}
+
+int main(int argc, char* argv[]) {
+    string filename = argv[argc - 1];
+    ifstream json_file(filename, ifstream::binary);
+
+    BidirectedGraph g;
+    bool ret = g.deserialize(json_file);
+
+    cout << "Serialization is a " << (ret ? "Success" : "Failure") << endl;
+
+    // Check edges
+    cout << "Original edges" << endl;
+    print_edges(g);
+
+    cout << "Min id: " << g.min_node_id() << endl;
+    cout << "Max id: " << g.max_node_id() << endl;
+
+    if (remove_node) {
+        cout << "Removed node 1" << endl;
+        g.destroy_handle(g.get_handle(1));
+        print_edges(g);
+    } else {
+        cout << "Removed edge 1-2" << endl;
+        g.destroy_edge(g.get_handle(1), g.get_handle(2));
+        print_edges(g);
+    }
+
+
+    return 0;
+}

--- a/test/bidirected/simple_bundle.json
+++ b/test/bidirected/simple_bundle.json
@@ -1,0 +1,27 @@
+{
+    "description": "This is a simple 1-2 bundle.",
+    "node": [
+        {
+            "id": 1,
+            "sequence": ""
+        },
+        {
+            "id": 2,
+            "sequence": ""
+        },
+        {
+            "id": 3,
+            "sequence": ""
+        }
+    ],
+    "edge": [
+        {
+            "from": 1,
+            "to": 2
+        },
+        {
+            "from": 1,
+            "to": 3
+        }
+    ]
+}


### PR DESCRIPTION
**Changes:**
1. Redesigned internal representation.
2. Implemented essential Deletable HG functions.
3. Deprecated BidirectedGraph functions that are now part of [algorithms](src/algorithms).

**Internal Representation Redesign**
The issue with the original design, which stored edges into a map where the key is the nid_t and the value is a vector of edge objects, was that deleting an edge would be an O(n) operation. Following the edges of a node side was also inefficient since it was an O(degree(left side of node) + degree(right side of node)) operation.
The new design stores edges into a map where the key is a directional handle_t and the value is a set of directional handle_t. This way deleting an edge would be an O(1) operation on average. Following the edges of a node side is also a bit more efficient since it's an O(degree(node side)) operation. A side benefit to this design is memory usage is also reduced despite still having a space complexity of O(E).